### PR TITLE
Mark aiger arguments as const * for functions not mutating the AIG

### DIFF
--- a/aiger.c
+++ b/aiger.c
@@ -113,6 +113,9 @@ aiger_version (void)
 #define IMPORT_private_FROM(p) \
   aiger_private * private = (aiger_private*) (p)
 
+#define IMPORT_const_private_FROM(p) \
+  aiger_private const * private = (aiger_private*) (p)
+
 #define EXPORT_public_FROM(p) \
   aiger * public = &(p)->public
 
@@ -635,9 +638,9 @@ aiger_error_usu (aiger_private * private,
 }
 
 const char *
-aiger_error (aiger * public)
+aiger_error (aiger const * public)
 {
-  IMPORT_private_FROM (public);
+  IMPORT_const_private_FROM (public);
   return private->error;
 }
 
@@ -1294,7 +1297,7 @@ aiger_write_ascii (aiger * public, void *state, aiger_put put)
 }
 
 static unsigned
-aiger_max_input_or_latch (aiger * public)
+aiger_max_input_or_latch (aiger const * public)
 {
   unsigned i, tmp, res;
 
@@ -1320,7 +1323,7 @@ aiger_max_input_or_latch (aiger * public)
 }
 
 int
-aiger_is_reencoded (aiger * public)
+aiger_is_reencoded (aiger const * public)
 {
   unsigned i, tmp, max, lhs;
   aiger_and *and;
@@ -2673,9 +2676,9 @@ aiger_open_and_read_from_file (aiger * public, const char *file_name)
 }
 
 const char *
-aiger_get_symbol (aiger * public, unsigned lit)
+aiger_get_symbol (aiger const * public, unsigned lit)
 {
-  IMPORT_private_FROM (public);
+  IMPORT_const_private_FROM (public);
   aiger_symbol *symbol;
   aiger_type *type;
   unsigned var;
@@ -2700,9 +2703,9 @@ aiger_get_symbol (aiger * public, unsigned lit)
 }
 
 static aiger_type *
-aiger_lit2type (aiger * public, unsigned lit)
+aiger_lit2type (aiger const * public, unsigned lit)
 {
-  IMPORT_private_FROM (public);
+  IMPORT_const_private_FROM (public);
   aiger_type *type;
   unsigned var;
 
@@ -2714,7 +2717,7 @@ aiger_lit2type (aiger * public, unsigned lit)
 }
 
 int
-aiger_lit2tag (aiger * public, unsigned lit) 
+aiger_lit2tag (aiger const * public, unsigned lit)
 {
   aiger_type * type;
   lit = aiger_strip (lit);
@@ -2726,7 +2729,7 @@ aiger_lit2tag (aiger * public, unsigned lit)
 }
 
 aiger_symbol *
-aiger_is_input (aiger * public, unsigned lit)
+aiger_is_input (aiger const * public, unsigned lit)
 {
   aiger_type *type;
   aiger_symbol *res;
@@ -2742,7 +2745,7 @@ aiger_is_input (aiger * public, unsigned lit)
 }
 
 aiger_symbol *
-aiger_is_latch (aiger * public, unsigned lit)
+aiger_is_latch (aiger const * public, unsigned lit)
 {
   aiger_symbol *res;
   aiger_type *type;
@@ -2758,7 +2761,7 @@ aiger_is_latch (aiger * public, unsigned lit)
 }
 
 aiger_and *
-aiger_is_and (aiger * public, unsigned lit)
+aiger_is_and (aiger const * public, unsigned lit)
 {
   aiger_type *type;
   aiger_and *res;

--- a/aiger.h
+++ b/aiger.h
@@ -268,7 +268,7 @@ int aiger_open_and_write_to_file (aiger *, const char *file_name);
  * data structures are updated accordingly including 'maxvar'.  The client
  * data within ANDs is reset to zero.
  */
-int aiger_is_reencoded (aiger *);
+int aiger_is_reencoded (aiger const *);
 void aiger_reencode (aiger *);
 
 /*------------------------------------------------------------------------*/
@@ -302,7 +302,7 @@ const char *aiger_read_generic (aiger *, void *state, aiger_get);
  * reach an invalid through a failed read attempt, or if 'aiger_check'
  * failed.
  */
-const char *aiger_error (aiger *);
+const char *aiger_error (aiger const *);
 
 /*------------------------------------------------------------------------*/
 /* Same semantics as with 'aiger_open_and_write_to_file' for reading.
@@ -328,7 +328,7 @@ unsigned aiger_strip_symbols_and_comments (aiger *);
  * Names for outputs are stored in the 'outputs' symbols and can only be
  * accesed through a linear traversal of the output symbols.
  */
-const char *aiger_get_symbol (aiger *, unsigned lit);
+const char *aiger_get_symbol (aiger const *, unsigned lit);
 
 /*------------------------------------------------------------------------*/
 /* Return tag of the literal:
@@ -339,7 +339,7 @@ const char *aiger_get_symbol (aiger *, unsigned lit);
  * 3 = and
  */
 
-int aiger_lit2tag (aiger *, unsigned lit);
+int aiger_lit2tag (aiger const *, unsigned lit);
 
 /*------------------------------------------------------------------------*/
 /* Check whether the given unsigned, e.g. even, literal was defined as
@@ -352,8 +352,8 @@ int aiger_lit2tag (aiger *, unsigned lit);
  * For outputs this is not possible, since the same literal may be used for
  * several outputs.
  */
-aiger_symbol *aiger_is_input (aiger *, unsigned lit);
-aiger_symbol *aiger_is_latch (aiger *, unsigned lit);
-aiger_and *aiger_is_and (aiger *, unsigned lit);
+aiger_symbol *aiger_is_input (aiger const *, unsigned lit);
+aiger_symbol *aiger_is_latch (aiger const *, unsigned lit);
+aiger_and *aiger_is_and (aiger const *, unsigned lit);
 
 #endif


### PR DESCRIPTION
This converts the AIG argument from `aiger *` to `aiger const *` for public functions that don't mutate the AIG.

This just makes using the library slightly nicer where you have functions that should only analyse the AIG, not modify it and shouldn't break any existing usage as `aiger *` is cast to `aiger const *` automatically.