### PR TITLE
Fix compressed file command allocation size

### DIFF
--- a/aiger.c
+++ b/aiger.c
@@ -1881,7 +1881,8 @@ aiger_open_and_write_to_file (aiger * public, const char *file_name)
 {
   IMPORT_private_FROM (public);
   int res, pclose_file;
-  char *cmd, size_cmd;
+  char *cmd;
+  size_t size_cmd;
   aiger_mode mode;
   FILE *file;
 
@@ -2689,7 +2690,8 @@ const char *
 aiger_open_and_read_from_file (aiger * public, const char *file_name)
 {
   IMPORT_private_FROM (public);
-  char *cmd, size_cmd;
+  char *cmd;
+  size_t size_cmd;
   const char *res;
   int pclose_file;
   FILE *file;

--- a/testaigtoaig.c
+++ b/testaigtoaig.c
@@ -168,6 +168,27 @@ write_and_read (aiger * old, const char *name)
   write_and_read_fmt (old, name, ".aig.gz");
 }
 
+static void
+write_and_read_long_compressed_name (void)
+{
+  aiger *old = my_aiger_init ();
+  aiger *new;
+  char file_name[105];
+
+  memcpy (file_name, "log/", 4);
+  memset (file_name + 4, 'l', 93);
+  memcpy (file_name + 97, ".aag.gz", 8);
+
+  assert (strlen (file_name) + strlen ("gzip -c > %s 2>/dev/null") == 128);
+  assert (aiger_open_and_write_to_file (old, file_name));
+
+  new = my_aiger_init ();
+  assert (!aiger_open_and_read_from_file (new, file_name));
+  aiger_reset (new);
+  aiger_reset (old);
+  assert (!mgr.bytes);
+}
+
 static char *empty_aig = "aag 0 0 0 0 0\n";
 
 static void
@@ -305,6 +326,7 @@ main (void)
   write_false ();
   write_true ();
   write_and ();
+  write_and_read_long_compressed_name ();
   reencode_counter1 ();
   return 0;
 }


### PR DESCRIPTION
This fixes the command buffer size used when opening compressed AIGER files.

The gzip/xz read and write paths stored the computed command length in a `char`. On platforms where `char` is signed, a sufficiently long `.gz` or `.xz` file name can wrap the size negative before it is passed to the allocation macro.

## Reproducer

With the original code, this small program triggers the issue through the public write API:

```c
#include "aiger.h"

#include <stdio.h>
#include <string.h>

int
main (void)
{
  aiger *model = aiger_init ();
  char file_name[105];
  size_t len;
  int ok;

  memset (file_name, 'a', 97);
  memcpy (file_name + 97, ".aig.gz", 8);

  len = strlen (file_name);
  fprintf (stderr, "file_name length: %zu\n", len);
  fprintf (stderr, "command length expression: %zu + %zu = %zu\n",
           len, strlen ("gzip -c > %s 2>/dev/null"),
           len + strlen ("gzip -c > %s 2>/dev/null"));

  ok = aiger_open_and_write_to_file (model, file_name);
  fprintf (stderr, "aiger_open_and_write_to_file returned: %d\n", ok);

  aiger_reset (model);
  return ok ? 0 : 1;
}
```

Compile and run with ASan:

```sh
cc -g -O0 -fsanitize=address -fno-omit-frame-pointer -I. \
  poc_size_cmd_write.c aiger.c -o poc_size_cmd_write
./poc_size_cmd_write
```

On macOS arm64 with Apple clang, the original code reports:

```text
file_name length: 104
command length expression: 104 + 24 = 128
ERROR: AddressSanitizer: requested allocation size 0xffffffffffffff80
    #1 aiger_default_malloc aiger.c:234
    #2 aiger_open_and_write_to_file aiger.c:1895
    #3 main poc_size_cmd_write.c:22
```

The computed size is assigned to `char size_cmd`. When the value reaches 128 on a platform with signed `char`, it becomes negative. The `NEWN` macro then converts that negative value to a huge `size_t` allocation request.

## Fix

Change the command length variable to `size_t` in both compressed write and compressed read paths. The read path uses the same pattern for gzip/xz command construction, so it is fixed together with the write-path reproducer.

This also adds a regression test that writes and reads a compressed file name whose command length expression reaches 128 bytes.

## Validation

- `./configure.sh`
- `make -f test.mk testaigtoaig`
- `./testaigtoaig`
- `git diff --check master...HEAD`
