### PR TITLE
Reject overflowing numeric header values

### DIFF
--- a/aiger.c
+++ b/aiger.c
@@ -28,6 +28,7 @@ IN THE SOFTWARE.
 #include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <unistd.h>
 
 /*------------------------------------------------------------------------*/
@@ -1966,18 +1967,30 @@ aiger_next_ch (aiger_reader * reader)
 /* Read a number assuming that the current character has already been
  * checked to be a digit, e.g. the start of the number to be read.
  */
-static unsigned
-aiger_read_number (aiger_reader * reader)
+static const char *
+aiger_read_number (aiger_private * private,
+		   aiger_reader * reader,
+		   const char * context,
+		   unsigned * res_ptr)
 {
-  unsigned res;
+  unsigned res, digit;
 
   assert (isdigit (reader->ch));
   res = reader->ch - '0';
 
   while (isdigit (aiger_next_ch (reader)))
-    res = 10 * res + (reader->ch - '0');
+    {
+      digit = reader->ch - '0';
+      if (res > (UINT_MAX - digit) / 10)
+	return aiger_error_us (private,
+			       "line %u: %s too large",
+			       reader->lineno_at_last_token_start, context);
+      res = 10 * res + digit;
+    }
 
-  return res;
+  *res_ptr = res;
+
+  return 0;
 }
 
 /* Expect and read an unsigned number followed by at least one white space
@@ -1995,6 +2008,7 @@ aiger_read_literal (aiger_private * private,
 		    char * followed_by_ptr)
 {
   unsigned res;
+  const char * error;
 
   assert (expected_followed_by == ' ' || 
           expected_followed_by == '\n' ||
@@ -2005,7 +2019,9 @@ aiger_read_literal (aiger_private * private,
 			  "line %u: expected %s",
 			  reader->lineno, context);
 
-  res = aiger_read_number (reader);
+  error = aiger_read_number (private, reader, context, &res);
+  if (error)
+    return error;
 
   if (expected_followed_by == ' ')
     {

--- a/aiger.c
+++ b/aiger.c
@@ -2168,6 +2168,11 @@ aiger_read_header (aiger * public, aiger_reader * reader)
 
   public->maxvar = reader->maxvar;
 
+  if (public->maxvar == UINT_MAX)
+    return aiger_error_u (private,
+			  "line %u: maximum variable index too large",
+			  reader->lineno_at_last_token_start);
+
   FIT (private->types, private->size_types, public->maxvar + 1);
   FIT (public->inputs, private->size_inputs, reader->inputs);
   FIT (public->latches, private->size_latches, reader->latches);

--- a/testaigtoaig.c
+++ b/testaigtoaig.c
@@ -185,6 +185,20 @@ read_number_overflow (void)
 }
 
 static void
+read_maxvar_overflow (void)
+{
+  aiger *aiger = my_aiger_init ();
+  const char *error;
+
+  error = aiger_read_from_string (aiger, "aag 4294967295 0 0 0 0\n");
+  assert (error);
+  assert (strstr (error, "maximum variable index too large"));
+
+  aiger_reset (aiger);
+  assert (!mgr.bytes);
+}
+
+static void
 write_empty (void)
 {
   aiger *aiger = my_aiger_init ();
@@ -316,6 +330,7 @@ main (void)
   cyclic0 ();
   cyclic1 ();
   read_number_overflow ();
+  read_maxvar_overflow ();
   write_empty ();
   write_false ();
   write_true ();

--- a/testaigtoaig.c
+++ b/testaigtoaig.c
@@ -171,6 +171,20 @@ write_and_read (aiger * old, const char *name)
 static char *empty_aig = "aag 0 0 0 0 0\n";
 
 static void
+read_number_overflow (void)
+{
+  aiger *aiger = my_aiger_init ();
+  const char *error;
+
+  error = aiger_read_from_string (aiger, "aag 4294967296 0 0 0 0\n");
+  assert (error);
+  assert (strstr (error, "maximum variable index too large"));
+
+  aiger_reset (aiger);
+  assert (!mgr.bytes);
+}
+
+static void
 write_empty (void)
 {
   aiger *aiger = my_aiger_init ();
@@ -301,6 +315,7 @@ main (void)
   rhs_undefined ();
   cyclic0 ();
   cyclic1 ();
+  read_number_overflow ();
   write_empty ();
   write_false ();
   write_true ();


### PR DESCRIPTION
This rejects two overflowing numeric header cases while parsing AIGER input.

The parser stores numeric fields in `unsigned`, but two boundary cases were not handled safely:

- Decimal tokens larger than `UINT_MAX` could wrap while being read by `aiger_read_number`.
- `maxvar == UINT_MAX` fits in `unsigned`, but the internal type table allocation needs `maxvar + 1` entries, which wraps to zero.

## Reproducer 1: decimal parser overflow

With the original code, this program accepts `UINT_MAX + 1` as the `maxvar` field and reads it as zero:

```c
#include "aiger.h"

#include <stdio.h>

int
main (void)
{
  aiger *model = aiger_init ();
  const char *input = "aag 4294967296 0 0 0 0\n";
  const char *error = aiger_read_from_string (model, input);

  printf ("input: %s", input);
  printf ("error: %s\n", error ? error : "<none>");
  printf ("maxvar: %u\n", model->maxvar);

  aiger_reset (model);
  return error ? 1 : 0;
}
```

Compile and run:

```sh
cc -g -O0 -I. poc_read_number_overflow.c aiger.c -o poc_read_number_overflow
./poc_read_number_overflow
```

Original output:

```text
input: aag 4294967296 0 0 0 0
error: <none>
maxvar: 0
```

With this patch, the same input is rejected:

```text
input: aag 4294967296 0 0 0 0
error: line 1: maximum variable index too large
maxvar: 0
```

## Reproducer 2: `maxvar + 1` allocation overflow

The value `4294967295` fits in `unsigned`, but the parser later allocates `public->maxvar + 1` type entries. With the original code, this input crashes under ASan:

```c
#include "aiger.h"

#include <stdio.h>

int
main (void)
{
  aiger *model = aiger_init ();
  const char *input = "aag 4294967295 0 0 0 0\n";
  const char *error = aiger_read_from_string (model, input);

  fprintf (stderr, "input: %s", input);
  fprintf (stderr, "error: %s\n", error ? error : "<none>");
  fprintf (stderr, "maxvar: %u\n", model->maxvar);

  aiger_reset (model);
  return error ? 1 : 0;
}
```

Compile and run with ASan:

```sh
cc -g -O0 -fsanitize=address -fno-omit-frame-pointer -I. \
  poc_header_uint_max.c aiger.c -o poc_header_uint_max
./poc_header_uint_max
```

Original output:

```text
AddressSanitizer:DEADLYSIGNAL
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008
    #0 aiger_check_for_cycles aiger.c:847
    #1 aiger_check aiger.c:921
    #2 aiger_read_generic aiger.c:2671
    #3 aiger_read_from_string aiger.c:2685
```

With this patch, the same input is rejected before allocating the type table:

```text
input: aag 4294967295 0 0 0 0
error: line 2: maximum variable index too large
maxvar: 4294967295
```

## Fix

`aiger_read_number` now checks the decimal accumulation before multiplying by 10 and adding the next digit:

```c
if (res > (UINT_MAX - digit) / 10)
  return aiger_error_us (...);
```

After reading the header, the parser also rejects `maxvar == UINT_MAX`, since the required `maxvar + 1` internal table size cannot be represented by the existing unsigned size field.

Regression tests cover both `4294967296` and `4294967295` header inputs.

## Validation

- `./configure.sh`
- `make -f test.mk testaigtoaig`
- `./testaigtoaig`
- `git diff --check master...HEAD`