### PR TITLE
Guard COI size overflow

### DIFF
--- a/aiger.c
+++ b/aiger.c
@@ -28,6 +28,7 @@ IN THE SOFTWARE.
 #include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <unistd.h>
 
 /*------------------------------------------------------------------------*/
@@ -1701,6 +1702,8 @@ const unsigned char *
 aiger_coi (aiger * public)
 {
   IMPORT_private_FROM (public);
+  if (public->maxvar == UINT_MAX)
+    return 0;
   private->size_coi = public->maxvar + 1;
   NEWN (private->coi, private->size_coi);
   memset (private->coi, 1, private->size_coi);

--- a/testaigtoaig.c
+++ b/testaigtoaig.c
@@ -171,6 +171,18 @@ write_and_read (aiger * old, const char *name)
 static char *empty_aig = "aag 0 0 0 0 0\n";
 
 static void
+coi_maxvar_overflow (void)
+{
+  aiger *aiger = my_aiger_init ();
+
+  aiger->maxvar = ~0u;
+  assert (!aiger_coi (aiger));
+
+  aiger_reset (aiger);
+  assert (!mgr.bytes);
+}
+
+static void
 write_empty (void)
 {
   aiger *aiger = my_aiger_init ();
@@ -301,6 +313,7 @@ main (void)
   rhs_undefined ();
   cyclic0 ();
   cyclic1 ();
+  coi_maxvar_overflow ();
   write_empty ();
   write_false ();
   write_true ();


### PR DESCRIPTION
This guards the size computation in `aiger_coi` when `maxvar` is `UINT_MAX`.

`aiger_coi` allocates one byte per variable index plus the constant slot, so it computes `public->maxvar + 1`. Since `maxvar` is an `unsigned`, `UINT_MAX + 1` wraps to zero before being stored in `private->size_coi`.

## Reproducer

The public `struct aiger` exposes `maxvar`, so the issue can be triggered through the public API surface:

```c
#include "aiger.h"

#include <limits.h>
#include <stdio.h>

int
main (void)
{
  aiger *model = aiger_init ();
  const unsigned char *coi;

  model->maxvar = UINT_MAX;
  fprintf (stderr, "maxvar: %u\n", model->maxvar);
  fprintf (stderr, "maxvar + 1 as unsigned: %u\n", model->maxvar + 1);

  coi = aiger_coi (model);
  fprintf (stderr, "coi pointer: %p\n", (void *) coi);
  fprintf (stderr, "coi[1]: %u\n", coi[1]);

  aiger_reset (model);
  return 0;
}
```

Compile and run with ASan:

```sh
cc -g -O0 -fsanitize=address -fno-omit-frame-pointer -I. \
  poc_coi_wrap.c aiger.c -o poc_coi_wrap
./poc_coi_wrap
```

Original output:

```text
maxvar: 4294967295
maxvar + 1 as unsigned: 0
coi pointer: 0x602000000110
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1
    #0 main poc_coi_wrap.c:18
    #2 aiger_coi aiger.c:1705
```

The overflowed size causes `aiger_coi` to allocate zero bytes for an array that is documented as covering `[1..maxvar]`. Accessing a normal COI slot then reads out of bounds.

## Fix

If `maxvar` is `UINT_MAX`, `maxvar + 1` cannot be represented by the existing unsigned `size_coi` field. In that case `aiger_coi` now returns `0` instead of creating a zero-sized COI array.

A regression test covers this boundary value.

## Validation

- `./configure.sh`
- `make -f test.mk testaigtoaig`
- `./testaigtoaig`
- `git diff --check master...HEAD`
