### PR TITLE
Reject overflowing maxvar header

### DIFF
--- a/aiger.c
+++ b/aiger.c
@@ -28,6 +28,7 @@ IN THE SOFTWARE.
 #include <stdlib.h>
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <unistd.h>
 
 /*------------------------------------------------------------------------*/
@@ -2151,6 +2152,11 @@ aiger_read_header (aiger * public, aiger_reader * reader)
     }
 
   public->maxvar = reader->maxvar;
+
+  if (public->maxvar == UINT_MAX)
+    return aiger_error_u (private,
+			  "line %u: maximum variable index too large",
+			  reader->lineno_at_last_token_start);
 
   FIT (private->types, private->size_types, public->maxvar + 1);
   FIT (public->inputs, private->size_inputs, reader->inputs);

--- a/testaigtoaig.c
+++ b/testaigtoaig.c
@@ -171,6 +171,20 @@ write_and_read (aiger * old, const char *name)
 static char *empty_aig = "aag 0 0 0 0 0\n";
 
 static void
+read_maxvar_overflow (void)
+{
+  aiger *aiger = my_aiger_init ();
+  const char *error;
+
+  error = aiger_read_from_string (aiger, "aag 4294967295 0 0 0 0\n");
+  assert (error);
+  assert (strstr (error, "maximum variable index too large"));
+
+  aiger_reset (aiger);
+  assert (!mgr.bytes);
+}
+
+static void
 write_empty (void)
 {
   aiger *aiger = my_aiger_init ();
@@ -301,6 +315,7 @@ main (void)
   rhs_undefined ();
   cyclic0 ();
   cyclic1 ();
+  read_maxvar_overflow ();
   write_empty ();
   write_false ();
   write_true ();


### PR DESCRIPTION
This rejects an AIGER header whose maximum variable index is `UINT_MAX`.

The parser stores `maxvar` as an `unsigned`, but later allocates the internal type table with `public->maxvar + 1` entries. If `maxvar` is `UINT_MAX`, that addition wraps to zero and leaves the model with no type table for a non-empty variable range.

## Reproducer

With the original code, this input crashes under ASan:

```c
#include "aiger.h"

#include <stdio.h>

int
main (void)
{
  aiger *model = aiger_init ();
  const char *input = "aag 4294967295 0 0 0 0\n";
  const char *error = aiger_read_from_string (model, input);

  fprintf (stderr, "input: %s", input);
  fprintf (stderr, "error: %s\n", error ? error : "<none>");
  fprintf (stderr, "maxvar: %u\n", model->maxvar);

  aiger_reset (model);
  return error ? 1 : 0;
}
```

Compile and run with ASan:

```sh
cc -g -O0 -fsanitize=address -fno-omit-frame-pointer -I. \
  poc_header_uint_max.c aiger.c -o poc_header_uint_max
./poc_header_uint_max
```

Original output:

```text
AddressSanitizer:DEADLYSIGNAL
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008
    #0 aiger_check_for_cycles aiger.c:847
    #1 aiger_check aiger.c:921
    #2 aiger_read_generic aiger.c:2671
    #3 aiger_read_from_string aiger.c:2685
```

The header value itself fits in `unsigned`, but the required internal table size `maxvar + 1` does not.

With this patch, the same input is rejected before the table allocation:

```text
input: aag 4294967295 0 0 0 0
error: line 2: maximum variable index too large
maxvar: 4294967295
```

## Fix

After reading the header and before allocating `private->types`, reject `public->maxvar == UINT_MAX`. That is the boundary value where `public->maxvar + 1` cannot be represented by the existing unsigned size field.

A regression test covers the `4294967295` header case.

## Validation

- `./configure.sh`
- `make -f test.mk testaigtoaig`
- `./testaigtoaig`
- `git diff --check master...HEAD`
