### PR TITLE
Check allocation failures before use

### DIFF
--- a/aiger.c
+++ b/aiger.c
@@ -59,7 +59,10 @@ aiger_version (void)
   do { \
     size_t bytes = (n) * sizeof (*(p)); \
     (p) = private->malloc_callback (private->memory_mgr, bytes); \
-    memset ((p), 0, bytes); \
+    if (bytes) { \
+      if (!(p)) abort (); \
+      memset ((p), 0, bytes); \
+    } \
   } while (0)
 
 #define REALLOCN(p,m,n) \
@@ -68,9 +71,12 @@ aiger_version (void)
     size_t nbytes = (n) * sizeof (*(p)); \
     size_t minbytes = (mbytes < nbytes) ? mbytes : nbytes; \
     void * res = private->malloc_callback (private->memory_mgr, nbytes); \
-    memcpy (res, (p), minbytes); \
-    if (nbytes > mbytes) \
-      memset (((char*)res) + mbytes, 0, nbytes - mbytes); \
+    if (nbytes) { \
+      if (!res) abort (); \
+      if (minbytes) memcpy (res, (p), minbytes); \
+      if (nbytes > mbytes) \
+	memset (((char*)res) + mbytes, 0, nbytes - mbytes); \
+    } \
     private->free_callback (private->memory_mgr, (p), mbytes); \
     (p) = res; \
   } while (0)
@@ -218,6 +224,8 @@ aiger_init_mem (void *memory_mgr,
   assert (external_malloc);
   assert (external_free);
   private = external_malloc (memory_mgr, sizeof (*private));
+  if (!private)
+    abort ();
   CLR (*private);
   private->memory_mgr = memory_mgr;
   private->malloc_callback = external_malloc;


### PR DESCRIPTION
This checks allocation results before using the returned pointers.

The library allows users to supply custom allocation callbacks through `aiger_init_mem`. Several internal allocation paths used the returned pointer immediately, even when the callback returned `NULL` for a non-zero allocation request.

## Reproducer

With the original code, this program makes the second allocation fail during initialization:

```c
#include "aiger.h"

#include <stdio.h>
#include <stdlib.h>

typedef struct manager manager;
struct manager { unsigned calls; };

static void *
failing_malloc (manager *mgr, size_t bytes)
{
  mgr->calls++;
  fprintf (stderr, "malloc call %u, bytes=%zu\n", mgr->calls, bytes);
  if (mgr->calls == 2)
    return 0;
  return malloc (bytes);
}

static void
failing_free (manager *mgr, void *ptr, size_t bytes)
{
  (void) mgr;
  (void) bytes;
  free (ptr);
}

int
main (void)
{
  manager mgr = { 0 };
  aiger *model = aiger_init_mem (&mgr,
                                 (aiger_malloc) failing_malloc,
                                 (aiger_free) failing_free);
  fprintf (stderr, "model: %p\n", (void *) model);
  aiger_reset (model);
  return 0;
}
```

Compile and run with ASan:

```sh
cc -g -O0 -fsanitize=address -fno-omit-frame-pointer -I. \
  poc_alloc_failure.c aiger.c -o poc_alloc_failure
./poc_alloc_failure
```

Original output:

```text
malloc call 1, bytes=216
malloc call 2, bytes=8
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
The signal is caused by a WRITE memory access.
    #0 _platform_memset
    #1 aiger_init_mem aiger.c:226
    #2 main poc_alloc_failure.c:31
```

The second allocation is the initial `PUSH` of the comments array. `REALLOCN` receives `NULL`, then writes to it with `memset`.

## Fix

For non-zero allocation requests, `NEWN` and `REALLOCN` now abort before using a `NULL` result. `aiger_init_mem` also checks the initial allocation before clearing the private state.

The macros also avoid calling `memset` or `memcpy` for zero-byte operations. That keeps zero-sized allocations separate from real allocation failures.

This is a fail-fast fix because most affected APIs do not have an error-return channel that could propagate allocation failure safely.

## Validation

- Reproducer above: original code reaches `memset(NULL, ...)`; patched code aborts before touching the null pointer
- `./configure.sh`
- `make -f test.mk testaigtoaig`
- `./testaigtoaig`
- `git diff --check master...HEAD`
